### PR TITLE
better entrypoint for python executable

### DIFF
--- a/usr/lib/python3/dist-packages/linuxmusterCli/main.py
+++ b/usr/lib/python3/dist-packages/linuxmusterCli/main.py
@@ -1,4 +1,4 @@
-#! /bin/python3
+#!/usr/bin/env python3
 
 import typer
 import subprocess


### PR DESCRIPTION
see: 
- https://peps.python.org/pep-0394/
- https://peps.python.org/pep-0397/#shebang-line-parsing

or use `/usr/bin/python3`.
At least on my system (upgraded from 7.1<-6.x<-5...) there is not python3 at `/bin/python3`.