### PR TITLE
Fixing groups of not registered devices not showing in lmncli devices

### DIFF
--- a/usr/lib/python3/dist-packages/linuxmusterCli/typers/devices.py
+++ b/usr/lib/python3/dist-packages/linuxmusterCli/typers/devices.py
@@ -49,5 +49,5 @@ def ls(
                 devices.add_row(device['room'], device['hostname'], device['group'], device['ip'], device['mac'], "Registered")
                 break
         else:
-            devices.add_row(device['room'], device['hostname'], device['ip'], device['mac'], "Not registered")
+            devices.add_row(device['room'], device['hostname'], device['group'], device['ip'], device['mac'], "Not registered")
     console.print(devices)


### PR DESCRIPTION
Groups of devices, which are not registered in LDAP are not added to the table . This causes a shift in the output.
```
┏━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━┓
┃ Room          ┃ Hostname           ┃ Group            ┃ IP                ┃ Mac               ┃ LDAP       ┃
┡━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━┩
│ pc1           │ nb1                │ win10efi         │ 10.0.0.1          │ XX:XX:XX:XX:XX:XX │ Registered │
│ pc2           │ nb2                │ 10.0.0.101       │ YY:YY:YY:YY:YY:YY │ Not registered    │            │
```

Adding the group the same way it was added [here](https://github.com/linuxmuster/linuxmuster-cli7/commit/4e8fa6b61838d86a5ea019af61749a74cbe73078) fixes the issue.